### PR TITLE
Refactored the ProfitBricks provider code per Google feedback.  Details in description.

### DIFF
--- a/perfkitbenchmarker/providers/profitbricks/flags.py
+++ b/perfkitbenchmarker/providers/profitbricks/flags.py
@@ -22,9 +22,9 @@ US_LAS = 'us/las'
 DE_FKB = 'de/fkb'
 DE_FRA = 'de/fra'
 
-# Zones
-ZONE_1 = 'ZONE_1'
-ZONE_2 = 'ZONE_2'
+# Boot Volume Types
+HDD = 'HDD'
+SSD = 'SSD'
 
 flags.DEFINE_string('profitbricks_config',
                     os.getenv('PROFITBRICKS_CONFIG',
@@ -33,30 +33,18 @@ flags.DEFINE_string('profitbricks_config',
                      'Can also be set via $PROFITBRICKS_CONFIG environment '
                      "variable.\n(File format: email:password)"))
 
-flags.DEFINE_enum('location',
+flags.DEFINE_enum('profitbricks_location',
                   US_LAS,
                   [US_LAS, DE_FKB, DE_FRA],
                   ('Location of data center to be provisioned (us/las, '
                    'de/fkb, de/fra)'))
 
-flags.DEFINE_integer('profitbricks_ram',
-                     None,
-                     ('Amount of RAM for the new server in multiples '
-                      'of 256 MB.'))
+flags.DEFINE_enum('profitbricks_boot_volume_type',
+                  HDD,
+                  [HDD, SSD],
+                  ('Choose between HDD or SSD boot volume types.'))
 
-flags.DEFINE_integer('profitbricks_cores',
-                     None,
-                     ('Number of cores for the new server.'))
-
-flags.DEFINE_string('profitbricks_disk_type',
-                    'HDD',
-                    ('Choose between HDD or SSD disk types.'))
-
-flags.DEFINE_integer('profitbricks_disk_size',
+flags.DEFINE_integer('profitbricks_boot_volume_size',
                      20,
-                     ('Choose the disk size in GB.'))
+                     ('Choose the boot volume size in GB.'))
 
-flags.DEFINE_enum('zone',
-                  ZONE_1,
-                  [ZONE_1, ZONE_2],
-                  ('Choose availability ZONE_1 or ZONE_2.'))

--- a/perfkitbenchmarker/providers/profitbricks/profitbricks_virtual_machine.py
+++ b/perfkitbenchmarker/providers/profitbricks/profitbricks_virtual_machine.py
@@ -15,9 +15,9 @@
 """
 
 import os
-import time
 import logging
 import base64
+import ast
 
 from perfkitbenchmarker import disk
 from perfkitbenchmarker import errors
@@ -25,6 +25,8 @@ from perfkitbenchmarker import flags
 from perfkitbenchmarker import linux_virtual_machine
 from perfkitbenchmarker import virtual_machine
 from perfkitbenchmarker import vm_util
+from perfkitbenchmarker.configs import option_decoders
+from perfkitbenchmarker.configs import spec
 from perfkitbenchmarker.providers import profitbricks
 from perfkitbenchmarker.providers.profitbricks import profitbricks_disk
 from perfkitbenchmarker.providers.profitbricks import util
@@ -32,8 +34,116 @@ from perfkitbenchmarker import providers
 
 PROFITBRICKS_API = profitbricks.PROFITBRICKS_API
 FLAGS = flags.FLAGS
-TIMEOUT = 25.0
-INTERVAL = 15
+TIMEOUT = 1500 # 25 minutes
+
+
+class CustomMachineTypeSpec(spec.BaseSpec):
+  """Properties of a ProfitBricks custom machine type.
+
+  Attributes:
+    cores: int. Number of CPU cores for a custom VM.
+    ram: int. Amount of RAM in MBs for a custom VM.
+  """
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+          The pair specifies a decoder class and its __init__() keyword
+          arguments to construct in order to decode the named option.
+    """
+    result = super(CustomMachineTypeSpec, cls)._GetOptionDecoderConstructions()
+    result.update({'cores': (option_decoders.IntDecoder, {'min': 1}),
+                   'ram': (option_decoders.IntDecoder, {'min': 1024})})
+    return result
+
+
+class MachineTypeDecoder(option_decoders.TypeVerifier):
+  """Decodes the machine_type option of a ProfitBricks VM config."""
+
+  def __init__(self, **kwargs):
+    super(MachineTypeDecoder, self).__init__((basestring, dict), **kwargs)
+
+  def Decode(self, value, component_full_name, flag_values):
+    """Decodes the machine_type option of a ProfitBricks VM config.
+
+    Args:
+      value: Either a string name of a PB machine type or a dict containing
+          'cpu' and 'memory' keys describing a custom VM.
+      component_full_name: string. Fully qualified name of the configurable
+          component containing the config option.
+      flag_values: flags.FlagValues. Runtime flag values to be propagated to
+          BaseSpec constructors.
+
+    Returns:
+      If value is a string, returns it unmodified. Otherwise, returns the
+      decoded CustomMachineTypeSpec.
+
+    Raises:
+      errors.Config.InvalidValue upon invalid input value.
+    """
+    super(MachineTypeDecoder, self).Decode(value, component_full_name,
+                                           flag_values)
+    if isinstance(value, basestring):
+      return value
+    return CustomMachineTypeSpec(self._GetOptionFullName(component_full_name),
+                                 flag_values=flag_values, **value)
+
+
+class ProfitBricksVmSpec(virtual_machine.BaseVmSpec):
+  """Object containing the information needed to create a
+  ProfitBricksVirtualMachine.
+
+  Attributes:
+    ram: None or int. RAM value in MB for custom ProfitBricks VM.
+    cores: None or int. CPU cores value for custom ProfitBricks VM.
+  """
+
+  CLOUD = providers.PROFITBRICKS
+
+  def __init__(self, *args, **kwargs):
+    super(ProfitBricksVmSpec, self).__init__(*args, **kwargs)
+    if isinstance(self.machine_type, CustomMachineTypeSpec):
+      logging.info('Using custom hardware configuration from config.')
+      self.cores = self.machine_type.cores
+      self.ram = self.machine_type.ram
+      self.machine_type = 'Custom (RAM: {}, Cores: {})'.format(
+        self.ram, self.cores)
+    else:
+      try:
+          hardware = ast.literal_eval(self.machine_type)
+          logging.info('Using custom hardware configuration from flag.')
+          self.ram = hardware['ram']
+          self.cores = hardware['cores']
+      except ValueError:
+          # ast.literal_eval() raises a ValueError if string can not
+          # be converted to a dict.  This means machine_type is a 
+          # preset, i.e. Small, Medium, Large, etc.
+          logging.info('Using preset hardware configuration.')
+          self.ram, self.cores = util.ReturnFlavor(self.machine_type)
+
+  @classmethod
+  def _GetOptionDecoderConstructions(cls):
+    """Gets decoder classes and constructor args for each configurable option.
+
+    Returns:
+      dict. Maps option name string to a (ConfigOptionDecoder class, dict) pair.
+          The pair specifies a decoder class and its __init__() keyword
+          arguments to construct in order to decode the named option.
+    """
+    result = super(ProfitBricksVmSpec, cls)._GetOptionDecoderConstructions()
+    result.update({
+        'machine_type': (MachineTypeDecoder, {}),
+        'profitbricks_location': (option_decoders.StringDecoder,
+                                 {'default': 'us/las'}),
+        'profitbricks_boot_volume_type': (option_decoders.StringDecoder,
+                                 {'default': 'HDD'}),
+        'profitbricks_boot_volume_size': (option_decoders.IntDecoder,
+                                 {'default': 10,
+                                  'min': 10})})
+    return result
 
 
 class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
@@ -57,7 +167,6 @@ class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
             user_creds = f.read().rstrip('\n')
             self.user_token = base64.b64encode(user_creds)
 
-        self.need_dc = True
         self.server_id = None
         self.server_status = None
         self.dc_id = None
@@ -66,13 +175,13 @@ class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
         self.lan_status = None
         self.max_local_disks = 1
         self.local_disk_counter = 0
+        self.ram = vm_spec.ram
+        self.cores = vm_spec.cores
+        self.machine_type = vm_spec.machine_type
         self.image = self.image or self.DEFAULT_IMAGE
-        self.ram = FLAGS.profitbricks_ram
-        self.cores = FLAGS.profitbricks_cores
-        self.profitbricks_disk_type = FLAGS.profitbricks_disk_type
-        self.disk_size = FLAGS.profitbricks_disk_size
-        self.location = FLAGS.location
-        self.zone = FLAGS.zone
+        self.boot_volume_type = FLAGS.profitbricks_boot_volume_type
+        self.boot_volume_size = FLAGS.profitbricks_boot_volume_size
+        self.location = FLAGS.profitbricks_location
         self.user_name = 'root'
         self.header = {
             'Authorization': 'Basic %s' % self.user_token,
@@ -89,14 +198,6 @@ class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
         # Find an Ubuntu image that matches our location
         self.image = util.ReturnImage(self.header, self.location)
 
-        # Find necessary specs for the user's machine_type selection
-        flavor_ram, flavor_cores = util.ReturnFlavor(self.machine_type)
-
-        if not self.ram:
-            self.ram = flavor_ram
-        if not self.cores:
-            self.cores = flavor_cores
-
         # Create server POST body
         new_server = {
             'properties': {
@@ -110,11 +211,10 @@ class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
                     'items': [
                         {
                             'properties': {
-                                'size': self.disk_size,
-                                'name': 'volume1',
+                                'size': self.boot_volume_size,
+                                'name': 'boot volume',
                                 'image': self.image,
-                                'bus': 'VIRTIO',
-                                'type': self.profitbricks_disk_type,
+                                'type': self.boot_volume_type,
                                 'sshKeys': [public_key]
                             }
                         }
@@ -184,7 +284,7 @@ class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
             raise errors.Error('VM deletion failed, see log.')
 
     def _CreateDependencies(self):
-        """Create a data center, NIC, and LAN prior to creating VM."""
+        """Create a data center and LAN prior to creating VM."""
 
         # Create data center
         self.dc_id, self.dc_status = util.CreateDatacenter(self.header,
@@ -199,7 +299,7 @@ class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
             raise errors.Error('LAN creation failed, see log.')
 
     def _DeleteDependencies(self):
-        """Delete a data center, NIC, and LAN."""
+        """Delete a data center and LAN."""
 
         # Build URL
         url = '%s/datacenters/%s' % (PROFITBRICKS_API, self.dc_id)
@@ -213,35 +313,19 @@ class ProfitBricksVirtualMachine(virtual_machine.BaseVirtualMachine):
         if not self._WaitUntilReady(delete_status):
             raise errors.Error('Data center deletion failed, see log.')
 
+    @vm_util.Retry(timeout=TIMEOUT, log_errors=False)
     def _WaitUntilReady(self, status_url):
         """Returns true if the ProfitBricks resource is ready."""
 
-        # Set counter
-        counter = 0
-
-        # Check status
+        # Poll resource for status update
         logging.info('Polling ProfitBricks resource.')
         r = util.PerformRequest('get', status_url, self.header)
         response = r.json()
         status = response['metadata']['status']
 
         # Keep polling resource until a "DONE" state is returned
-        while status != 'DONE':
-
-            # Wait before polling again
-            time.sleep(INTERVAL)
-
-            # Check status
-            logging.info('Polling ProfitBricks resource.')
-            r = util.PerformRequest('get', status_url, self.header)
-            response = r.json()
-            status = response['metadata']['status']
-
-            # Check for timeout
-            counter += 0.25
-            if counter >= TIMEOUT:
-                logging.debug('Timed out after waiting %s minutes.' % TIMEOUT)
-                return False
+        if status != 'DONE':
+            raise Exception # Exception triggers vm_util.Retry to go again
 
         return True
 

--- a/perfkitbenchmarker/providers/profitbricks/util.py
+++ b/perfkitbenchmarker/providers/profitbricks/util.py
@@ -40,6 +40,7 @@ def PerformRequest(action, url, header, json=None):
     # Check Response Status Code
     if r.status_code >= 300:
         action = action.upper()
+        logging.info(r.text)
         raise errors.Error('%s call to %s failed, see log.' % (action,
                                                                url))
 
@@ -57,7 +58,7 @@ def ReturnImage(header, location):
 
     # Search for Ubuntu image in preferred zone
     for image in response['items']:
-        if('Ubuntu-15' in image['properties']['name'] and
+        if('Ubuntu-14' in image['properties']['name'] and
            image['properties']['location'] == location):
             return image['id']
 


### PR DESCRIPTION
Added the ProfitBricksVmSpec class to allow provider specific flags to
be declared in user config files.  Added support to the machine_type
flag to allow for preset names such as “Small”, “Medium”, etc. as well
as custom hardware values like “{‘cores’: 1, ‘ram’: 2048}”.  These
custom values may also be used in config files.Updated the
profitbricks_disk_type and profitbricks_disk_size flags to be more
semantic.  Removed my own polling logic and now use vm_util.Retry().